### PR TITLE
Produce working

### DIFF
--- a/mkdockerize.sh
+++ b/mkdockerize.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 set -e
 
+# Build and output to stdout
 if [ "$1" = 'produce' ]; then
-	echo "to be implemented"
+	mkdocs build
+# Optionally create site.tar.gz in page directory
+	if [ "$2" = 'local' ]; then
+		tar -zcvf site.tar.gz site
+	fi
+	exec tar -zcvf - site
+# This will take over the process and serve the page
+# Exiting the process will stop and kill the container
 elif [ "$1" = 'serve' ]; then
 	exec mkdocs serve --dev-addr=0.0.0.0:8000
 else


### PR DESCRIPTION
Added produce function
Default it will build the page site, compress and output to stdout
Optionally "local" parameter can be added after produce to create a site.tar.gz in the shared volume site folder